### PR TITLE
Go certstrap

### DIFF
--- a/bin/jumpbox
+++ b/bin/jumpbox
@@ -237,7 +237,7 @@ install_bosh_cli() {
 install_certstrap() {
 	sudo rm -f /usr/local/bin/certstrap || true
 	sudo curl -o /usr/local/bin/certstrap \
-	https://raw.githubusercontent.com/starkandwayne/jumpbox/go_certstrap/bin/certstrap
+	https://raw.githubusercontent.com/starkandwayne/jumpbox/master/bin/certstrap
 	sudo chmod 0755 /usr/local/bin/certstrap
 	echo "Installed certstrap"
 }

--- a/bin/jumpbox
+++ b/bin/jumpbox
@@ -236,7 +236,7 @@ install_bosh_cli() {
 
 install_golang() {
 	if ! have go version ${1}; then 
-		sudo apt-get install golang-go
+		sudo apt-get install golang-go || sudo yum install golang
 		mkdir ${HOME}/work
 		export GOPATH=${HOME}/work >> ${HOME}/.profile
 		export PATH=${PATH >> ${HOME}/.profile
@@ -349,7 +349,7 @@ case "$1" in
 	install_vault     ${WANT_VAULT_VERSION:-0.6.0}
 	install_bosh_init ${WANT_BOSH_INIT_VERSION:-0.0.81}
 	install_genesis   ${WANT_GENESIS_VERSION:-latest}
-        install_golang    ${WANT_GOLANG_VERSION:-1.6}
+	install_golang    ${WANT_GOLANG_VERSION:-1.6}
 	install_certstrap 
 	passwordless_sudo
 	all_done

--- a/bin/jumpbox
+++ b/bin/jumpbox
@@ -234,6 +234,27 @@ install_bosh_cli() {
 	fi
 }
 
+install_golang() {
+	if ! have go version ${1}; then 
+		sudo apt-get install golang-go
+		mkdir ${HOME}/work
+		export GOPATH=${HOME}/work >> ${HOME}/.profile
+		export PATH=${PATH >> ${HOME}/.profile
+		go get github.com/tools/godep
+	fi
+}
+
+install_certstrap() {
+	rm -rf certstrap || true
+	sudo rm -f /usr/local/bin/certstrap || true
+	git clone https://github.com/square/certstrap
+	cd certstrap
+	./build
+	sudo mv ./bin/certstrap /usr/local/bin/certstrap
+	rm -rf ../certstrap
+	echo "Installed Certstrap"
+}
+
 passwordless_sudo() {
 	groupadd jumpbox
 	if ! grep -q '%jumpbox' /etc/sudoers; then
@@ -328,6 +349,8 @@ case "$1" in
 	install_vault     ${WANT_VAULT_VERSION:-0.6.0}
 	install_bosh_init ${WANT_BOSH_INIT_VERSION:-0.0.81}
 	install_genesis   ${WANT_GENESIS_VERSION:-latest}
+        install_golang    ${WANT_GOLANG_VERSION:-1.6}
+	install_certstrap 
 	passwordless_sudo
 	all_done
 	;;

--- a/bin/jumpbox
+++ b/bin/jumpbox
@@ -234,21 +234,12 @@ install_bosh_cli() {
 	fi
 }
 
-install_golang() {
-	if ! have go version ${1}; then 
-		sudo apt-get install golang-go || sudo yum install golang
-	fi
-}
-
 install_certstrap() {
-	rm -rf certstrap || true
 	sudo rm -f /usr/local/bin/certstrap || true
-	git clone https://github.com/square/certstrap
-	cd certstrap
-	./build
-	sudo mv ./bin/certstrap /usr/local/bin/certstrap
-	rm -rf ../certstrap
-	echo "Installed Certstrap"
+	sudo curl -o /usr/local/bin/certstrap \
+	https://raw.githubusercontent.com/starkandwayne/jumpbox/go_certstrap/bin/certstrap
+	sudo chmod 0755 /usr/local/bin/certstrap
+	echo "Installed certstrap"
 }
 
 passwordless_sudo() {
@@ -345,7 +336,6 @@ case "$1" in
 	install_vault     ${WANT_VAULT_VERSION:-0.6.0}
 	install_bosh_init ${WANT_BOSH_INIT_VERSION:-0.0.81}
 	install_genesis   ${WANT_GENESIS_VERSION:-latest}
-	install_golang    ${WANT_GOLANG_VERSION:-1.6}
 	install_certstrap 
 	passwordless_sudo
 	all_done

--- a/bin/jumpbox
+++ b/bin/jumpbox
@@ -237,10 +237,6 @@ install_bosh_cli() {
 install_golang() {
 	if ! have go version ${1}; then 
 		sudo apt-get install golang-go || sudo yum install golang
-		mkdir ${HOME}/work
-		export GOPATH=${HOME}/work >> ${HOME}/.profile
-		export PATH=${PATH >> ${HOME}/.profile
-		go get github.com/tools/godep
 	fi
 }
 


### PR DESCRIPTION
Due to needing certstrap for the Cloud Foundry Genesis Deployment, this update installs certstrap to the jumpbox.